### PR TITLE
make UIColor private

### DIFF
--- a/RHPlaceholder/RHPlaceholder/RHPlaceholderSource/Animations/Utils/UIColor+HEX.swift
+++ b/RHPlaceholder/RHPlaceholder/RHPlaceholderSource/Animations/Utils/UIColor+HEX.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public extension UIColor {
+extension UIColor {
 
     /// Usage:
     /// let color = UIColor(red: 0xFF, green: 0xFF, blue: 0xFF)


### PR DESCRIPTION
The UIColor extensions is currently marked as public. So it may conflict with another libraries